### PR TITLE
Name interfaces when connecting nodes, fixed cleanup and run outside docker

### DIFF
--- a/marvis/channel/csma.py
+++ b/marvis/channel/csma.py
@@ -75,7 +75,7 @@ class CSMAChannel(Channel):
             else:
                 interface = Interface(node=node, ns3_device=ns3_device, address=connected_node.address)
             ns3_device.SetAddress(ns_net.Mac48Address(interface.mac_address))
-            node.add_interface(interface)
+            node.add_interface(interface, type_prefix='csma')
             self.interfaces.append(interface)
 
     def prepare(self, simulation):

--- a/marvis/channel/csma.py
+++ b/marvis/channel/csma.py
@@ -75,7 +75,7 @@ class CSMAChannel(Channel):
             else:
                 interface = Interface(node=node, ns3_device=ns3_device, address=connected_node.address)
             ns3_device.SetAddress(ns_net.Mac48Address(interface.mac_address))
-            node.add_interface(interface, type_prefix='csma')
+            node.add_interface(interface, name=connected_node.ifname)
             self.interfaces.append(interface)
 
     def prepare(self, simulation):

--- a/marvis/channel/wifi.py
+++ b/marvis/channel/wifi.py
@@ -271,7 +271,7 @@ class WiFiChannel(Channel):
             else:
                 interface = Interface(node=node, ns3_device=ns3_device, address=connected_node.address)
             ns3_device.SetAddress(ns_net.Mac48Address(interface.mac_address))
-            node.add_interface(interface, type_prefix='wifi')
+            node.add_interface(interface, name=connected_node.ifname)
             self.interfaces.append(interface)
 
 

--- a/marvis/channel/wifi.py
+++ b/marvis/channel/wifi.py
@@ -61,7 +61,7 @@ class WiFiChannel(Channel):
         #: Standard from 2013.
         WIFI_802_11ac = wifi.WIFI_PHY_STANDARD_80211ac
         #: "WiFi 6".
-        WIFI_802_11ax = wifi.WIFI_PHY_STANDARD_80211ax
+        # WIFI_802_11ax = wifi.WIFI_PHY_STANDARD_80211ax
         #: Wireless Access in Vehicular Environments (WAVE).
         WIFI_802_11p = wifi.WIFI_PHY_STANDARD_80211_10MHZ
 
@@ -271,7 +271,7 @@ class WiFiChannel(Channel):
             else:
                 interface = Interface(node=node, ns3_device=ns3_device, address=connected_node.address)
             ns3_device.SetAddress(ns_net.Mac48Address(interface.mac_address))
-            node.add_interface(interface)
+            node.add_interface(interface, type_prefix='wifi')
             self.interfaces.append(interface)
 
 

--- a/marvis/channel/wifi.py
+++ b/marvis/channel/wifi.py
@@ -61,7 +61,8 @@ class WiFiChannel(Channel):
         #: Standard from 2013.
         WIFI_802_11ac = wifi.WIFI_PHY_STANDARD_80211ac
         #: "WiFi 6".
-        WIFI_802_11ax = wifi.WIFI_PHY_STANDARD_80211ax
+        # Deactivated due to incompatible ns-3 version
+        # WIFI_802_11ax = wifi.WIFI_PHY_STANDARD_80211ax
         #: Wireless Access in Vehicular Environments (WAVE).
         WIFI_802_11p = wifi.WIFI_PHY_STANDARD_80211_10MHZ
 

--- a/marvis/channel/wifi.py
+++ b/marvis/channel/wifi.py
@@ -61,7 +61,7 @@ class WiFiChannel(Channel):
         #: Standard from 2013.
         WIFI_802_11ac = wifi.WIFI_PHY_STANDARD_80211ac
         #: "WiFi 6".
-        # WIFI_802_11ax = wifi.WIFI_PHY_STANDARD_80211ax
+        WIFI_802_11ax = wifi.WIFI_PHY_STANDARD_80211ax
         #: Wireless Access in Vehicular Environments (WAVE).
         WIFI_802_11p = wifi.WIFI_PHY_STANDARD_80211_10MHZ
 

--- a/marvis/interface.py
+++ b/marvis/interface.py
@@ -187,8 +187,16 @@ class Interface:
         logger.debug('Create veth pair %s on bridge %s', self.veth_name, self.bridge_name)
         peer['address'] = self.mac_address
         ipr.link('add', ifname=self.veth_name, peer=peer, kind='veth')
+        defer(f'disconnect veth for ns3 node {self.node.name}', self.remove_veth_pair)
         ipr.link('set', ifname=self.veth_name, master=ipr.link_lookup(ifname=self.bridge_name)[0])
         ipr.link('set', ifname=self.veth_name, state='up')
+
+    def remove_veth_pair(self):
+        """Disconnect the veth pair and delete it."""
+        ipr = IPRoute()
+
+        logger.debug('Disconnect %s from veth via %s', self.node.name, self.veth_name)
+        ipr.link('del', ifname=self.veth_name)
 
     def setup_veth_container_end(self, ifname):
         """Setup the VETH in a container.

--- a/marvis/mobility_input/mobility_provider.py
+++ b/marvis/mobility_input/mobility_provider.py
@@ -1,7 +1,38 @@
-"""Interface class for providing co-simulation positional status output."""
-
 class MobilityProvider:
+    """Interface class for providing co-simulation positional status output."""
 
-    def getVehicleDetails(vehId):
-        """This function returns if the vehicle is currently simulated on the map and if yes, furter details."""
+    def getVehicleDetails(self, vehId):
+        """
+        Return current vehicle status. If the vehicle is not part of the simulation, `isVehicleActive` will be False.
+        Only if `isVehicleActive` is True the other fields contain correct values.
+
+        Parameters
+        ----------
+        vehId - str
+            The id of the vehicle in SUMO.
+        """
+        raise NotImplementedError
+
+    def stopAtEndOfCurrentSegment(self, vehId, duration=0):
+        """
+        Schedule a stop the end of the current road segment for `vehId`. The stop will last `duration` seconds.
+
+        Parameters
+        ----------
+        vehId - str
+            The id of the vehicle in SUMO.
+        duration - float
+            The duration of the stop (default: 0)
+        """
+        raise NotImplementedError
+
+    def resumeOrCancelStop(self, vehId):
+        """
+        Resume from a stop or remove the scheduled stop.
+
+        Parameters
+        ----------
+        vehId - str
+            The id of the vehicle in SUMO.
+        """
         raise NotImplementedError

--- a/marvis/mobility_input/mobility_provider.py
+++ b/marvis/mobility_input/mobility_provider.py
@@ -1,0 +1,7 @@
+"""Interface class for providing co-simulation positional status output."""
+
+class MobilityProvider:
+
+    def getVehicleDetails(vehId):
+        """This function returns if the vehicle is currently simulated on the map and if yes, furter details."""
+        raise NotImplementedError

--- a/marvis/mobility_input/mobility_provider_server.py
+++ b/marvis/mobility_input/mobility_provider_server.py
@@ -1,0 +1,41 @@
+import logging
+import threading
+
+from xmlrpc.server import SimpleXMLRPCServer
+
+logger = logging.getLogger(__name__)
+
+class RPCMobilityProviderServer:
+    """
+    RPCMobilityProviderServer is a RPC server which wraps an `MobilityProvider` to serve traffic requests.
+    The RPC server will be started in a separate thread.
+
+    Parameters
+    ----------
+    connection_details : tuple
+        A tuple containing connection information: (ip, port, log_requests)
+    mobility_provider_cl : class
+        The class of the MobilityProvider to be wrapped.
+    mobility_provider_args : tuple
+        Arguments that will be passed to the mobility_provider on instantiation
+    """
+    def __init__(self, connection_details, mobility_provider_cl, mobility_provider_args=()):
+
+        self.server = SimpleXMLRPCServer(connection_details[:2], logRequests=connection_details[2], allow_none=True)
+        
+        self.mobility_handler = threading.Thread(target=self.run, args=[mobility_provider_cl, self.server, mobility_provider_args])
+        self.mobility_handler.setDaemon(True)  # Daemonize thread
+        self.mobility_handler.start()  # Start the execution
+
+    def run(self, mobility_provider_cl, server, mobility_provider_args):
+        """Creates a `MobilityProvider` instance and registers it to serve requests."""
+        mobility_provider_inst = mobility_provider_cl(mobility_provider_args)
+        server.register_instance(mobility_provider_inst, allow_dotted_names=True)
+        server.serve_forever()
+
+    def stop(self):
+        """Stops the RPC server and waits for the containing thread to join."""
+        logger.info("Shutting down server")
+        self.server.shutdown()
+        self.mobility_handler.join()
+

--- a/marvis/mobility_input/null_lock.py
+++ b/marvis/mobility_input/null_lock.py
@@ -1,0 +1,13 @@
+class NullLock():
+    """
+    This class implements the interface of `threading.Lock` as a Null Object.
+    """
+    
+    def acquire(self):
+        pass
+
+    def release(self):
+        pass
+
+    def locked(self):
+        pass

--- a/marvis/mobility_input/sumo.py
+++ b/marvis/mobility_input/sumo.py
@@ -30,7 +30,10 @@ class SumoMobilityProvider(MobilityProvider):
         return {
             "isVehicleActive": 0 if not vehicleIsActive else 1,
             "position3d": (0.0, 0.0, 0.0) if not vehicleIsActive else traci.vehicle.getPosition3D(vehId),
-            "speed": 0.0 if not vehicleIsActive else traci.vehicle.getSpeed(vehId)
+            "speed": 0.0 if not vehicleIsActive else traci.vehicle.getSpeed(vehId),
+            # From ETSI TS 102 894-2:
+            # The value shall be set to 1022 if the vehicle length is equal to or greater than 102,2 metres.
+            "lengthInCentimeter": 0 if not vehicleIsActive else min(1022, int(traci.vehicle.getLength(vehId) * 10))
         }
 
 class RPCServer:

--- a/marvis/mobility_input/sumo.py
+++ b/marvis/mobility_input/sumo.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 class SumoMobilityProvider(MobilityProvider):
     def getVehicleDetails(vehId):
-        vehId = "train"
         vehicleIsActive = vehId in traci.vehicle.getIDList()
         
         return {
@@ -35,6 +34,9 @@ class SumoMobilityProvider(MobilityProvider):
             # The value shall be set to 1022 if the vehicle length is equal to or greater than 102,2 metres.
             "lengthInCentimeter": 0 if not vehicleIsActive else min(1022, int(traci.vehicle.getLength(vehId) * 10))
         }
+
+    def setSpeed(vehId, newSpeed):
+        traci.vehicle.setSpeed(vehId, newSpeed)
 
 class RPCServer:
     def __init__(self, connection_details):

--- a/marvis/mobility_input/sumo.py
+++ b/marvis/mobility_input/sumo.py
@@ -6,51 +6,121 @@ import sys
 import threading
 import time
 
-from xmlrpc.server import SimpleXMLRPCServer
+from .mobility_input import MobilityInput
+from .mobility_provider import MobilityProvider
+from .mobility_provider_server import RPCMobilityProviderServer
 
+from .null_lock import NullLock
+
+# Include SUMO tools to path to access TraCI or Libsumo
 if 'SUMO_HOME' in os.environ:
     tools = os.path.join(os.environ['SUMO_HOME'], 'tools')
     sys.path.append(tools)
 else:
     sys.exit("Please declare environment variable 'SUMO_HOME'")
 
-# Use libsumo to avoid multithreading problems with traci
-import libsumo as traci
 
-from .mobility_input import MobilityInput
-from .mobility_provider import MobilityProvider
+# =================================================================================
+# The SUMO mobility input can be controlled by two ways:
+# * TraCI
+# * Libsumo
+#
+# TraCI allows to start or connect to SUMO and communicate via sockets. Even though multiple TraCI clients can connect to the same SUMO server, this method is not suitable for mobility providers running in a separate thread. Simulation will only proceed if all clients called `simulationStep()`, which is a blocking function.
+# Connection objects can be shared, but the methods are not thread safe. Access to TraCI therefore needs to be managed via synchronization objects. It is not yet analyzed, how large numbers of request for `SumoMobilityProvider` influence the simulation execution, as they might block the simulation due to the shared connection. In this case, using Libsumo and `NullLock`s can prevent this problem.
+# 
+# Libsumo allows to use SUMO as a library without the overhead of sockets and similar techniques. However, this method is limited, e.g. no support for SUMO-GUI. Because of its library-style, functions can be called in different threads. Therefore, synchronization is not necessary and a `NullLock` can be used to avoid changing the source code to remove synchronization calls.
+#
+# Find more information here:
+# TraCI: https://sumo.dlr.de/docs/TraCI.html
+# Libsumo: https://sumo.dlr.de/docs/Libsumo.html
+# =================================================================================
+
+
+USE_LIBSUMO = False
+
+if USE_LIBSUMO:
+    import libsumo as traci
+else:
+    import traci
 
 logger = logging.getLogger(__name__)
 
 class SumoMobilityProvider(MobilityProvider):
-    def getVehicleDetails(vehId):
-        vehicleIsActive = vehId in traci.vehicle.getIDList()
-        
-        return {
-            "isVehicleActive": 0 if not vehicleIsActive else 1,
-            "position3d": (0.0, 0.0, 0.0) if not vehicleIsActive else traci.vehicle.getPosition3D(vehId),
-            "speed": 0.0 if not vehicleIsActive else traci.vehicle.getSpeed(vehId),
-            # From ETSI TS 102 894-2:
-            # The value shall be set to 1022 if the vehicle length is equal to or greater than 102,2 metres.
-            "lengthInCentimeter": 0 if not vehicleIsActive else min(1022, int(traci.vehicle.getLength(vehId) * 10))
-        }
+    """
+    SumoMobilityProvider is an interface for applications to get traffic simulation data or influence the simulation.
 
-    def setSpeed(vehId, newSpeed):
-        traci.vehicle.setSpeed(vehId, newSpeed)
+    The SumoMobilityProvider will be wrapped by a server to serve traffic requests.
+    """
 
-class RPCServer:
-    def __init__(self, connection_details):
-        self._running = True
-        self.connection_details = connection_details
+    def __init__(self, lock):
+        # A lock object to access a shared connection
+        # This might be necessary when using TraCI
+        self.lock = lock
+        self.logger = logging.getLogger(__name__ + ".mobility_provider")
 
-        thread = threading.Thread(target=self.run, args=())
-        thread.daemon = True  # Daemonize thread
-        thread.start()  # Start the execution
+    def getVehicleDetails(self, vehId):
+        self.lock.acquire()
 
-    def run(self):
-        server = SimpleXMLRPCServer(self.connection_details, allow_none=True)
-        server.register_instance(SumoMobilityProvider, allow_dotted_names=True)
-        server.serve_forever()
+        try:
+            vehicleIsActive = vehId in traci.vehicle.getIDList()
+            vehicle_details = {
+                "isVehicleActive": 0 if not vehicleIsActive else 1,
+                "position3d": (0.0, 0.0, 0.0) if not vehicleIsActive else traci.vehicle.getPosition3D(vehId),
+                "speed": 0.0 if not vehicleIsActive else traci.vehicle.getSpeed(vehId),
+                # From ETSI TS 102 894-2:
+                # The value shall be set to 1022 if the vehicle length is equal to or greater than 102,2 metres.
+                "lengthInCentimeter": 0 if not vehicleIsActive else min(1022, int(traci.vehicle.getLength(vehId) * 10))
+            }
+        except traci.exceptions.TraCIException as e:
+            self.logger.error(f"Caught TraCI exception. {e.getType()}: {e} Command: {e.getCommand()}")
+        except traci.exceptions.FatalTraCIError as e:
+            self.logger.error(f"Fatal TraCI error caught for {self.name}. Reason: {e}.")
+        except Exception:
+            pass
+        self.lock.release()
+
+        return vehicle_details
+
+    def stopAtEndOfCurrentSegment(self, vehId, duration=0):
+        self.lock.acquire()
+        try:
+            end_of_road_segment = traci.lane.getLength(traci.vehicle.getLaneID(vehId))
+            traci.vehicle.setStop(
+                vehId,
+                traci.vehicle.getRoadID(vehId),
+                pos=end_of_road_segment,
+                laneIndex=traci.vehicle.getLaneIndex(vehId),
+                duration=1.0*duration
+            )
+        except traci.exceptions.TraCIException as e:
+            self.logger.error(f"Caught TraCI exception. {e.getType()}: {e} Command: {e.getCommand()}")
+        except traci.exceptions.FatalTraCIError as e:
+            self.logger.error(f"Fatal TraCI error caught for {self.name}. Reason: {e}.")
+        except Exception:
+            pass
+        self.lock.release()
+
+    def resumeOrCancelStop(self, vehId):
+        self.lock.acquire()
+        try:
+            if traci.vehicle.isStopped(vehId):
+                traci.vehicle.resume(vehId)
+            else:
+                end_of_road_segment = traci.lane.getLength(traci.vehicle.getLaneID(vehId))
+                traci.vehicle.setStop(
+                    vehId,
+                    traci.vehicle.getRoadID(vehId),
+                    pos=end_of_road_segment,
+                    laneIndex=traci.vehicle.getLaneIndex(vehId),
+                    duration=0.0
+                )
+        except traci.exceptions.TraCIException as e:
+            self.logger.error(f"Caught TraCI exception. {e.getType()}: {e} Command: {e.getCommand()}")
+        except traci.exceptions.FatalTraCIError as e:
+            self.logger.error(f"Fatal TraCI error caught for {self.name}. Reason: {e}.")
+        except Exception:
+            pass
+        self.lock.release()
 
 class SUMOMobilityInput(MobilityInput):
     """SUMOMobilityInput is an interface to the SUMO simulation environment.
@@ -84,14 +154,14 @@ class SUMOMobilityInput(MobilityInput):
     steplength : float
         The length of each simulation step in seconds (default: 1).
         It only has effect in the local mode.
-    rpc_server : tuple
+    rpc_server_config : tuple
         Starts a rpc server if value is not None.
-        The tuple needs two elements: (ip, port).
+        The tuple needs three elements: (ip, port, log_requests).
     """
 
     def __init__(self, name="SUMO External Simulation", steps=1000,
                  sumo_host='localhost', sumo_port=8813, sumo_cmd="sumo",
-                 config_path=None, step_length=1, rpc_server=None):
+                 config_path=None, step_length=1, rpc_server_config=None):
         super().__init__(name)
         #: The host on which the SUMO simulation is running.
         #:
@@ -111,8 +181,12 @@ class SUMOMobilityInput(MobilityInput):
         self.step_length = step_length
         #: The number of steps to simulate in SUMO.
         self.step_counter = 0
+        #: The RPC server if rpc_server_config is not None
+        self.rpc_server = None
         #: The connection details of the RPC server
-        self.rpc_server = rpc_server
+        self.rpc_server_config = rpc_server_config
+        #: The lock to acquire traci connection
+        self.lock = NullLock() if USE_LIBSUMO else threading.Lock()
 
     def prepare(self, simulation):
         """Connect to SUMO server."""
@@ -123,9 +197,9 @@ class SUMOMobilityInput(MobilityInput):
             traci.start([self.sumo_cmd, "--step-length", str(self.step_length), '-c', self.config_path])
         self.step_counter = 0
 
-        if self.rpc_server is not None:
-            logger.info("Starting RPC server on %s:%d", self.rpc_server[0], self.rpc_server[1])
-            RPCServer(self.rpc_server)
+        if self.rpc_server_config is not None:
+            logger.info(f"Starting RPC server on {self.rpc_server_config[0]}:{self.rpc_server_config[1]}. Logs requests: {self.rpc_server_config[2]}")
+            self.rpc_server = RPCMobilityProviderServer(self.rpc_server_config, SumoMobilityProvider, (self.lock))
 
     def start(self):
         """Start a thread stepping through the sumo simulation."""
@@ -133,6 +207,7 @@ class SUMOMobilityInput(MobilityInput):
         def run_sumo():
             try:
                 while self.step_counter < self.steps:
+                    self.lock.acquire()
                     traci.simulationStep()
                     step_start_time = time.time()
 
@@ -150,12 +225,14 @@ class SUMOMobilityInput(MobilityInput):
                         node.set_position(x, y, z)
 
                     self.step_counter = self.step_counter + 1
+                    delta_t = traci.simulation.getDeltaT()
                     time_this_step = time.time() - step_start_time
-                    time.sleep(traci.simulation.getDeltaT() - time_this_step)
+                    self.lock.release()
+                    time.sleep(max(0, delta_t - time_this_step))
             except traci.exceptions.TraCIException as e:
-                logger.error(f"Caught TraCI exception. Type: {e.getType()} Command: {e.getCommand()}")
+                logger.error(f"Caught TraCI exception. {e.getType()}: {e} Command: {e.getCommand()}")
             except traci.exceptions.FatalTraCIError as e:
-                logger.error(f"Fatal TraCI error caught for {self.name}. Maybe the connection was closed.")
+                logger.error(f"Fatal TraCI error caught for {self.name}. Reason: {e}.")
                 sys.exit(1)
 
         thread = threading.Thread(target=run_sumo)
@@ -180,6 +257,11 @@ class SUMOMobilityInput(MobilityInput):
     def destroy(self):
         """Stop SUMO."""
         logger.info('Trying to close SUMO for %s.', self.name)
-        # Trigger abort of loop.
+        # Abort SUMO simulation loop
         self.step_counter = self.steps
+        # Stop RPC mobility provider server
+        self.rpc_server.stop()
+        if self.lock.locked():
+            self.lock.release()
+        # Stop SUMO and TraCI
         traci.close()

--- a/marvis/network.py
+++ b/marvis/network.py
@@ -221,7 +221,7 @@ class ChannelPrototype:
         self.nodes = list()
         self.channel = None  # After creation, this will be the channel object
 
-    def connect(self, node, ip_addr=None):
+    def connect(self, node, ip_addr=None, ifname=None):
         """Adds one node to the channel.
 
         Please note: Every node can only be added to one channel in the same network. Otherwise proper routing is not
@@ -234,6 +234,9 @@ class ChannelPrototype:
         ip_addr : str
             The IP address of that node. If :code:`None` an random IP from the network will be assigned.
             If not :code:`None` the IP address have to be in the range of the network.
+        ifname : str
+            The name of the interface. If :code:`None` a random name will be assigned.
+            If not :code:`None` the max. length is :code:`IFNAMSIZ` (system depended). This will not be checked.
         """
         if node in self.network.nodes and not isinstance(node, SwitchNode):
             raise ValueError("Every node can only be in one channel of a network.")
@@ -242,7 +245,7 @@ class ChannelPrototype:
         if ip_addr is not None:
             address = ipaddress.ip_address(ip_addr)
             self.network.allocated_ip_addresses.append(address)
-        self.nodes.append(ConnectedNode(node, address))
+        self.nodes.append(ConnectedNode(node, address, ifname=ifname))
         self.network.nodes.append(node)
 
     def set_delay(self, delay):
@@ -273,6 +276,7 @@ class ChannelPrototype:
 
 
 class ConnectedNode:
-    def __init__(self, node, address):
+    def __init__(self, node, address, ifname=None):
         self.node = node
         self.address = address
+        self.ifname = ifname

--- a/marvis/node/base.py
+++ b/marvis/node/base.py
@@ -67,7 +67,7 @@ class Node:
         mobility_model = self.ns3_node.GetObject(mobility.MobilityModel.GetTypeId())
         mobility_model.SetPosition(core.Vector(self.position[0], self.position[1], self.position[2]))
 
-    def add_interface(self, interface, name=None, prefix='eth'):
+    def add_interface(self, interface, name=None, prefix='eth', type_prefix=''):
         """Add an interface to the node.
 
         *Warning:* Do not call this function manually.
@@ -87,7 +87,7 @@ class Node:
             raise ValueError(f'Interface {name} already added')
         if name is None:
             for i in range(256):
-                test = f'ns3-{prefix}{i}'
+                test = f'ns3-{prefix}-{type_prefix}{i}'
                 if test not in self.interfaces:
                     name = test
                     break

--- a/marvis/node/base.py
+++ b/marvis/node/base.py
@@ -87,7 +87,7 @@ class Node:
             raise ValueError(f'Interface {name} already added')
         if name is None:
             for i in range(256):
-                test = f'ns3-{prefix}-{i}'
+                test = f'ns3-{prefix}{i}'
                 if test not in self.interfaces:
                     name = test
                     break

--- a/marvis/node/base.py
+++ b/marvis/node/base.py
@@ -67,7 +67,7 @@ class Node:
         mobility_model = self.ns3_node.GetObject(mobility.MobilityModel.GetTypeId())
         mobility_model.SetPosition(core.Vector(self.position[0], self.position[1], self.position[2]))
 
-    def add_interface(self, interface, name=None, prefix='eth', type_prefix=''):
+    def add_interface(self, interface, name=None, prefix='eth'):
         """Add an interface to the node.
 
         *Warning:* Do not call this function manually.
@@ -87,7 +87,7 @@ class Node:
             raise ValueError(f'Interface {name} already added')
         if name is None:
             for i in range(256):
-                test = f'ns3-{prefix}-{type_prefix}{i}'
+                test = f'ns3-{prefix}-{i}'
                 if test not in self.interfaces:
                     name = test
                     break

--- a/marvis/simulation.py
+++ b/marvis/simulation.py
@@ -101,10 +101,12 @@ class Simulation:
         logger.info('Preparing simulation')
 
         # Add host to hostsfile.
-        ipr = IPRoute()
-        host_ip = ipr.get_addr(label='docker0')[0].get_attr('IFA_ADDRESS')
         self.hosts = defaultdict(list)
-        self.hosts['host'].append(host_ip)
+        ipr = IPRoute()
+        docker_network_interfaces = ipr.get_addr(label='docker0')
+        if len(docker_network_interfaces) > 0:
+            host_ip = ipr.get_addr(label='docker0')[0].get_attr('IFA_ADDRESS')
+            self.hosts['host'].append(host_ip)
 
         # Try to add influxdb to hosts file (if container is running).
         try:

--- a/marvis/simulation.py
+++ b/marvis/simulation.py
@@ -101,9 +101,11 @@ class Simulation:
         logger.info('Preparing simulation')
 
         # Add host to hostsfile.
-        self.hosts = defaultdict(list)
         ipr = IPRoute()
+        self.hosts = defaultdict(list)
         docker_network_interfaces = ipr.get_addr(label='docker0')
+        # if executed in docker, use docker0 interface as host
+        # docker0 is not always present, e.g. when using WSL
         if len(docker_network_interfaces) > 0:
             host_ip = ipr.get_addr(label='docker0')[0].get_attr('IFA_ADDRESS')
             self.hosts['host'].append(host_ip)


### PR DESCRIPTION
I added the possibility to name interfaces when connecting nodes. For example: `csma_channel.connect(node, ifname="fancy_ifname")`. -> The interface inside the node will now be named `fancy_ifname`. Deterministic names are useful, e.g. if the application is listenting for messages at one specific interface. The usual restrictions for interface names apply (e.g. on most systems max length of 15 characters).

I also added a cleanup for the veth pair. This way it is possible to re-execute simulations (previously: `pyroute2.netlink.exceptions.NetlinkError: (17, 'File exists')`).

Further I added support to run Marvis in WSL (and outside a development container).
When using WSL there is no interface `docker0`, so the original marvis code will break (`marvis/simulation.py`).
By checking if there is the interface `docker0` first, we can prevent this problem.

Still open is the edge case, when Marvis is executed outside of an container on a host which has docker installed. In this case we still would see the `docker0` interface and therefore add its IP as `host` to the `hosts` file, even though this is not correct.