### PR TITLE
Workflow: run smoke test on correct docker tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
-name: Build images and smoke test
+name: Build images, smoke test, and push if on master
 'on':
   - push
-  - pull_request 
+  - pull_request
   - workflow_dispatch
 
 jobs:
@@ -16,14 +16,8 @@ jobs:
       - name: Build all images
         run: make -C repo all latest
 
-      - name: Smoke test basic_example.py
-        run: |
-          cd repo
-          docker run --rm \
-            --net host --pid host --userns host --privileged \
-            -v /var/run/docker.sock:/var/run/docker.sock:ro \
-            -v $PWD/examples:/examples -w /examples \
-            ghcr.io/diselab/marvis python3 ./basic_example.py
+      - name: Smoke test
+        run: make -C repo smoke-test-marvis
 
       - name: Login to GitHub Container Registry
         if: github.ref == 'refs/heads/master'

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -17,7 +17,7 @@ def main():
 
     with scenario as sim:
         # To simulate forever, do not specify the simulation_time parameter.
-        sim.simulate(simulation_time=60)
+        sim.simulate(simulation_time=30)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
to make sure that the smoke test is actually run on the correct tag, the corresponding line is moved to the makefile – i guess it belongs there anyways. 

---
[Documentation of `fix_run_smoke_test_on_correct_image`](https://diselab.github.io/marvis/fix_run_smoke_test_on_correct_image)