### PR TITLE
Change network setup to reflect current api of marivs.network.__init__ in ssh_example

### DIFF
--- a/examples/ssh_example.py
+++ b/examples/ssh_example.py
@@ -4,7 +4,8 @@ from marvis import ArgumentParser, Scenario, Network, SwitchNode, DockerNode, SS
 def main():
     scenario = Scenario()
 
-    net = Network("10.0.0.0", "255.255.255.0", delay="200ms")
+    net = Network("10.0.0.0", "255.255.255.0")
+    net.set_delay(delay="200ms")
 
     node1 = DockerNode('pong', docker_build_dir='./docker/pong')
     node2 = SwitchNode('bridge-1')


### PR DESCRIPTION
The current version of the ssh_example is no longer working probably due to a change in the __init__ function in marvis.network. 
This fixes the example by calling the method instead of passing the parameter during init.