### PR TITLE
fix network probe in entrypoint to be compatible with sh

### DIFF
--- a/examples/docker/curl-webserver/entrypoint.sh
+++ b/examples/docker/curl-webserver/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-until ip a show ns3-eth0 &> /dev/null
+until ip a show ns3-eth0 > /dev/null 2>&1
 do
   echo 'waiting for network connection ...'
   sleep 1

--- a/examples/docker/fault-tolerant-app/temperature-server/entrypoint.sh
+++ b/examples/docker/fault-tolerant-app/temperature-server/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-until ip a show ns3-eth0 &> /dev/null
+until ip a show ns3-eth0 > /dev/null 2>&1
 do
   echo 'waiting for network connection ...'
   sleep 1

--- a/examples/docker/fault-tolerant-app/temperature-voter/entrypoint.sh
+++ b/examples/docker/fault-tolerant-app/temperature-voter/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-until ip a show ns3-eth0 &> /dev/null
+until ip a show ns3-eth0 > /dev/null 2>&1
 do
   echo 'waiting for network connection ...'
   sleep 1

--- a/examples/docker/ping/entrypoint.sh
+++ b/examples/docker/ping/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-until ip a show ns3-eth0 &> /dev/null
+until ip a show ns3-eth0 > /dev/null 2>&1
 do
   echo 'waiting for network connection ...'
   sleep 1

--- a/examples/docker/pong/entrypoint.sh
+++ b/examples/docker/pong/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-until ip a show ns3-eth0 &> /dev/null
+until ip a show ns3-eth0 > /dev/null 2>&1
 do
   echo 'waiting for network connection ...'
   sleep 1

--- a/examples/docker/sumo/entrypoint.sh
+++ b/examples/docker/sumo/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-until ip a show ns3-eth0 &> /dev/null
+until ip a show ns3-eth0 > /dev/null 2>&1
 do
   echo 'waiting for network connection ...'
   sleep 1


### PR DESCRIPTION
Changes all `entrypoint.sh` scripts used in the examples. 
`&>` is bashism and doesn't work with the used shell. I replaced it with the posix compatible way to ensure it working regardless of the used shell. 

