### PR TITLE
Fix bug with parsing of ipr.get_links()

### DIFF
--- a/tools/cleanup
+++ b/tools/cleanup
@@ -10,7 +10,7 @@ def main(logger, dry_run, images, all_images):
     ipr = IPRoute()
     links = ipr.get_links()
     for link in links:
-        name = link.IFLA_IFNAME.value
+        name = link.get("attrs")[0][1]
         if '-ns3-' in name:
             logger.info('remove interface %s', name)
             if not dry_run:


### PR DESCRIPTION
The Cleanup script didn't work for me due to an error in parsing the return of the link object that gets returned by ipr.get_links()

The beginning of the returned object looks like this(line breaks added for clarity):

```
{
  'family': 0,
  '__align': (),
  'ifi_type': 772,
  'index': 1,
  'flags': 65609,
  'change': 0,
  'attrs': [
     ('IFLA_IFNAME', 'lo'),
     ('IFLA_TXQLEN', 1000), 
[...]
}
```

